### PR TITLE
delete before check to avoid KeeperException$NoNodeException (#1062)

### DIFF
--- a/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/zk/AbstractZKClient.java
+++ b/dolphinscheduler-common/src/main/java/org/apache/dolphinscheduler/common/zk/AbstractZKClient.java
@@ -201,8 +201,10 @@ public abstract class AbstractZKClient {
         for(String serverPath : deadServers){
             if(serverPath.startsWith(serverType+UNDERLINE+host)){
 				String server = getDeadZNodeParentPath() + SINGLE_SLASH + serverPath;
-				zkClient.delete().forPath(server);
-                logger.info("{} server {} deleted from zk dead server path success" , serverType , host);
+				if(zkClient.checkExists().forPath(server) != null){
+					zkClient.delete().forPath(server);
+					logger.info("{} server {} deleted from zk dead server path success" , serverType , host);
+				}
             }
         }
 	}


### PR DESCRIPTION
* move updateTaskState into try/catch block in case of exception

* fix NPE

* using conf.getInt instead of getString

* for AbstractZKClient, remove the log, for it will print the same log message in createZNodePath.
for AlertDao, correct the spelling.

* duplicate

* refactor getTaskWorkerGroupId

* add friendly log

* update hearbeat thread num = 1

* fix the bug when worker execute task using queue. and remove checking Tenant user anymore in TaskScheduleThread

* 1. move verifyTaskInstanceIsNull after taskInstance
2. keep verifyTenantIsNull/verifyTaskInstanceIsNull clean and readable

* fix the message

* delete before check to avoid KeeperException$NoNodeException