### PR TITLE
fix CheckUtils.checkUserParams method (#1090)

### DIFF
--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ExecutorController.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/controller/ExecutorController.java
@@ -95,7 +95,7 @@ public class ExecutorController extends BaseController {
                     workerGroupId, timeout);
 
             if (timeout == null) {
-                timeout = org.apache.dolphinscheduler.common.Constants.MAX_TASK_TIMEOUT;
+                timeout = Constants.MAX_TASK_TIMEOUT;
             }
 
             Map<String, Object> result = execService.execProcessInstance(loginUser, projectName, processDefinitionId, scheduleTime, execType, failureStrategy,

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/UsersService.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/service/UsersService.java
@@ -94,15 +94,17 @@ public class UsersService extends BaseService {
                                           String queue) throws Exception {
 
         Map<String, Object> result = new HashMap<>(5);
-        result = CheckUtils.checkUserParams(userName, userPassword, email, phone);
-        if (result.get(Constants.STATUS) != Status.SUCCESS) {
+        if (!CheckUtils.checkUserParams(userName, userPassword, email, phone)) {
+            putMsg(result, Status.REQUEST_PARAMS_NOT_VALID_ERROR);
             return result;
         }
-        if (check(result, !isAdmin(loginUser), Status.USER_NO_OPERATION_PERM)) {
+        if (!isAdmin(loginUser)) {
+            putMsg(result, Status.USER_NO_OPERATION_PERM);
             return result;
         }
 
-        if (check(result, checkTenant(tenantId), Status.TENANT_NOT_EXIST)) {
+        if (checkTenant(tenantId)) {
+            putMsg(result, Status.TENANT_NOT_EXIST);
             return result;
         }
 

--- a/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/CheckUtils.java
+++ b/dolphinscheduler-api/src/main/java/org/apache/dolphinscheduler/api/utils/CheckUtils.java
@@ -42,7 +42,7 @@ public class CheckUtils {
    * @param userName
    */
   public static boolean checkUserName(String userName) {
-    return regexChecks(userName, org.apache.dolphinscheduler.common.Constants.REGEX_USER_NAME);
+    return regexChecks(userName, Constants.REGEX_USER_NAME);
   }
 
   /**
@@ -51,7 +51,7 @@ public class CheckUtils {
    * @param email
    */
   public static boolean checkEmail(String email) {
-    return email.length() > 5 && email.length() <= 40 && regexChecks(email, org.apache.dolphinscheduler.common.Constants.REGEX_MAIL_NAME) ;
+    return email.length() > 5 && email.length() <= 40 && regexChecks(email, Constants.REGEX_MAIL_NAME) ;
   }
 
   /**
@@ -123,25 +123,12 @@ public class CheckUtils {
    * @param phone
    * @return
    */
-  public static Map<String, Object> checkUserParams(String userName, String password, String email, String phone){
-      Map<String, Object> result = new HashMap<>();
-     try{
-       CheckUtils.checkUserName(userName);
-       CheckUtils.checkEmail(email);
-       CheckUtils.checkPassword(password);
-       CheckUtils.checkPhone(phone);
-       result.put(Constants.STATUS, Status.SUCCESS);
-       result.put(Constants.MSG, Status.SUCCESS.getMsg());
-     }catch (Exception e){
-       result.put(Constants.STATUS, Status.REQUEST_PARAMS_NOT_VALID_ERROR);
-       result.put(Constants.MSG, e.getMessage());
-     }
-      return result;
+  public static boolean checkUserParams(String userName, String password, String email, String phone){
+    return CheckUtils.checkUserName(userName) &&
+            CheckUtils.checkEmail(email) &&
+            CheckUtils.checkPassword(password) &&
+            CheckUtils.checkPhone(phone);
   }
-
-
-
-
 
   /**
    * 正则匹配


### PR DESCRIPTION
* move updateTaskState into try/catch block in case of exception

* fix NPE

* using conf.getInt instead of getString

* for AbstractZKClient, remove the log, for it will print the same log message in createZNodePath.
for AlertDao, correct the spelling.

* duplicate

* refactor getTaskWorkerGroupId

* add friendly log

* update hearbeat thread num = 1

* fix the bug when worker execute task using queue. and remove checking Tenant user anymore in TaskScheduleThread

* 1. move verifyTaskInstanceIsNull after taskInstance
2. keep verifyTenantIsNull/verifyTaskInstanceIsNull clean and readable

* fix the message

* delete before check to avoid KeeperException$NoNodeException

* fix the message

* check processInstance state before delete tenant

* check processInstance state before delete worker group

* refactor

* merge api constants into common constatns

* update the resource perm

* update the dataSource perm

* fix CheckUtils.checkUserParams method