### PR TITLE
fix ZKWorkerClient not close PathChildrenCache (#1185)

### DIFF
--- a/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/zk/ZKWorkerClient.java
+++ b/dolphinscheduler-server/src/main/java/org/apache/dolphinscheduler/server/zk/ZKWorkerClient.java
@@ -28,7 +28,6 @@ import org.apache.curator.utils.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Date;
 import java.util.concurrent.ThreadFactory;
 
 
@@ -49,15 +48,13 @@ public class ZKWorkerClient extends AbstractZKClient {
 	 */
 	private String workerZNode = null;
 
-	/**
-	 *  create time
-	 */
-	private Date createTime = null;
 
 	/**
 	 *  zkWorkerClient
 	 */
 	private static ZKWorkerClient zkWorkerClient = null;
+
+	private PathChildrenCache workerPathChildrenCache;
 
 	private ZKWorkerClient(){
 		init();
@@ -76,6 +73,16 @@ public class ZKWorkerClient extends AbstractZKClient {
 
 		// register worker
 		this.registWorker();
+	}
+
+	public void close(){
+		try {
+			if(workerPathChildrenCache != null){
+				workerPathChildrenCache.close();
+			}
+			super.close();
+		} catch (Exception ignore) {
+		}
 	}
 
 
@@ -112,13 +119,10 @@ public class ZKWorkerClient extends AbstractZKClient {
 	 *  monitor worker
 	 */
 	private void listenerWorker(){
-		PathChildrenCache workerPc = new PathChildrenCache(zkClient, getZNodeParentPath(ZKNodeType.WORKER), true, defaultThreadFactory);
+		workerPathChildrenCache = new PathChildrenCache(zkClient, getZNodeParentPath(ZKNodeType.WORKER), true, defaultThreadFactory);
 		try {
-
-			Date now = new Date();
-			createTime = now ;
-			workerPc.start();
-			workerPc.getListenable().addListener(new PathChildrenCacheListener() {
+			workerPathChildrenCache.start();
+			workerPathChildrenCache.getListenable().addListener(new PathChildrenCacheListener() {
 				@Override
 				public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
 					switch (event.getType()) {


### PR DESCRIPTION
* move updateTaskState into try/catch block in case of exception

* fix NPE

* using conf.getInt instead of getString

* for AbstractZKClient, remove the log, for it will print the same log message in createZNodePath.
for AlertDao, correct the spelling.

* duplicate

* refactor getTaskWorkerGroupId

* add friendly log

* update hearbeat thread num = 1

* fix the bug when worker execute task using queue. and remove checking Tenant user anymore in TaskScheduleThread

* 1. move verifyTaskInstanceIsNull after taskInstance
2. keep verifyTenantIsNull/verifyTaskInstanceIsNull clean and readable

* fix the message

* delete before check to avoid KeeperException$NoNodeException

* fix the message

* check processInstance state before delete tenant

* check processInstance state before delete worker group

* refactor

* merge api constants into common constatns

* update the resource perm

* update the dataSource perm

* fix CheckUtils.checkUserParams method

* update AlertGroupService, extends from BaseService, remove duplicate methods

* refactor

* modify method name

* add hasProjectAndPerm method

* using checkProject instead of getResultStatus

* delete checkAuth method, using hasProjectAndPerm instead.

* correct spelling

* add transactional for deleteWorkerGroupById

* add Transactional for deleteProcessInstanceById method

* change sqlSessionTemplate singleton

* change sqlSessionTemplate singleton and reformat code

* fix unsuitable error message

* update shutdownhook methods

* fix worker log bug

* fix api server debug mode bug

* upgrade zk version

* delete this line ,for zkClient.close() will do the whole thing

* fix master server shutdown error

* degrade zk version and add FourLetterWordMain class

* fix PathChildrenCache not close